### PR TITLE
Invalid Parsing with Objects #38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </distributionManagement>
 
     <properties>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
         <jamm.version>0.4.1</jamm.version>
         <jackson.version>2.13.2.2</jackson.version>
         <gson.version>2.9.0</gson.version>
@@ -150,7 +150,26 @@
             <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>compile</scope>
+        </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.skyscreamer/jsonassert -->
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 
@@ -290,7 +309,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+<!--                        <version>1.6.8</version>-->
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/src/main/java/com/techatpark/sjson/schema/ObjectSchema.java
+++ b/src/main/java/com/techatpark/sjson/schema/ObjectSchema.java
@@ -1,5 +1,4 @@
 package com.techatpark.sjson.schema;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Map;
@@ -13,9 +12,10 @@ public class ObjectSchema extends JsonSchema<Object> {
     ObjectSchema(final Map<String, Object> schemaAsMap) {
         super(schemaAsMap);
     }
-
     @Override
     public final Object read(final Reader reader) throws IOException {
         return null;
     }
+
+
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,6 +4,7 @@
 module json.parser {
     requires java.base;
     requires jakarta.validation;
+    requires junit;
 
     opens com.techatpark.sjson.core.util;
     opens com.techatpark.sjson.schema.generator;

--- a/src/test/java/com/techatpark/sjson/core/JsonTest.java
+++ b/src/test/java/com/techatpark/sjson/core/JsonTest.java
@@ -8,10 +8,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,6 +82,24 @@ class JsonTest {
      */
     private static Set<Path> jsonFilesProvider() throws IOException {
         return TestUtil.getJSONFiles();
+    }
+
+    @Test
+    void testJSon() throws IOException {
+        String jsonText = """
+                {
+                  
+                  "negZeroKey": -0.0
+                 
+                
+                }
+                """;
+        Map<String,Object> ourJsonObject = (Map<String, Object>) new Json().read(new StringReader(jsonText));
+        JsonNode jacksonJsonNode = new ObjectMapper().readTree(jsonText);
+        String reversedJsonText = jackson.writeValueAsString(ourJsonObject);
+        JSONAssert.assertEquals(
+                jsonText, reversedJsonText, JSONCompareMode.LENIENT);
+
     }
 
 }


### PR DESCRIPTION
Added test case for invalid parsing with object, added dependency for jsonassert in pom file.

Reason of test case failure was jackson handling negative zero value differently as compared to json.