### PR TITLE
Invalid Parsing with Objects #38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,13 @@
             <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/org.skyscreamer/jsonassert -->
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/test/java/com/techatpark/sjson/core/JsonTest.java
+++ b/src/test/java/com/techatpark/sjson/core/JsonTest.java
@@ -8,10 +8,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,6 +72,24 @@ class JsonTest {
         String nullSJson = sJson.jsonText(sJsonAsMap);
 
         Assertions.assertEquals(nullJson, nullSJson);
+    }
+
+    @Test
+    void testJSon() throws IOException {
+        String jsonText = """
+                {
+                  
+                  "negZeroKey": -0.0
+                 
+                
+                }
+                """;
+        Map<String,Object> ourJsonObject = (Map<String, Object>) new Json().read(new StringReader(jsonText));
+        JsonNode jacksonJsonNode = new ObjectMapper().readTree(jsonText);
+        String reversedJsonText = jackson.writeValueAsString(ourJsonObject);
+        JSONAssert.assertEquals(
+                jsonText, reversedJsonText, JSONCompareMode.LENIENT);
+
     }
 
     /**


### PR DESCRIPTION
Added test case for Invalid Parsing with Object.
Added dependency in pom.xml file for Jsonassert.
Failure was because jackson was handling negative zero differently as compared to json.
Fixed that by using Jsonassert.